### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: Use pre-commit
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/ethawn234/ContosoPizza/security/code-scanning/2](https://github.com/ethawn234/ContosoPizza/security/code-scanning/2)

To fix the problem, you should add an explicit `permissions` block to the workflow to ensure the `GITHUB_TOKEN` used by all jobs is limited to the minimum required. This is generally set at the top level of the YAML workflow for all jobs or at the job level. Since this workflow runs readonly checks (does not need to push, modify PRs, etc.), the best and most minimal setting is `permissions: contents: read` at the root level (below `name:` and above `on:`). No other code or functionality needs to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
